### PR TITLE
ZynAddSubfx 3.0.6

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.ZynFusion.json
+++ b/org.freedesktop.LinuxAudio.Plugins.ZynFusion.json
@@ -18,9 +18,11 @@
         "prefix": "/app/extensions/Plugins/ZynFusion",
         "prepend-path": "/app/extensions/Plugins/ZynFusion/bin",
         "prepend-ld-library-path": "/app/extensions/Plugins/ZynFusion/lib",
-        "prepend-pkg-config-path": "/app/extensions/Plugins/ZynFusion/lib/pkgconfig"
+        "prepend-pkg-config-path": "/app/extensions/Plugins/ZynFusion/lib/pkgconfig",
+        "cppflags": "-I/app/extensions/Plugins/ZynFusion/include"
     },
     "modules": [
+        "shared-modules/linux-audio/fftw3f-static.json",
         "shared-modules/linux-audio/liblo-static.json",
         "shared-modules/linux-audio/lv2.json",
         "shared-modules/python2.7/python-2.7.json",
@@ -36,12 +38,10 @@
                 "--disable-shared"
             ],
             "cleanup": [
-                "/lib/libmxml.a",
+                "*.a",
                 "/lib/pkgconfig",
                 "/share",
                 "/include"
-            ],
-            "post-install": [
             ],
             "sources": [
                 {
@@ -52,13 +52,33 @@
             ]
         },
         {
+            "name": "libuv",
+            "build-options": {
+                "cflags": "-fPIC"
+            },
+            "config-opts": [
+                "--disable-shared",
+                "--enable-static"
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "*.a",
+                "*.la"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url":"http://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz",
+                    "sha256": "e83953782c916d7822ef0b94e8115ce5756fab5300cca173f0de5f5b0e0ae928"
+                }
+            ]
+        },
+        {
             "name": "zest",
             "buildsystem": "simple",
             "build-commands": [
-                "mv libuv-v1.9.1.tar.gz deps/",
                 "ruby rebuild-fcache.rb",
-                "make setup",
-                "make builddep",
                 "make clean",
                 "rm -f package/qml/*.qml",
                 "ruby rebuild-fcache.rb",
@@ -66,12 +86,11 @@
             ],
             "build-options": {
                 "env": {
-                    "VERSION": "3.0.6-rc1",
+                    "CFLAGS": "-I/app/extensions/Plugins/ZynFusion/include",
+                    "VERSION": "3.0.6",
                     "BUILD_MODE": "release"
                 }
             },
-            "cleanup": [
-            ],
             "post-install": [
                 "install -d $FLATPAK_DEST/lib/qml",
                 "touch $FLATPAK_DEST/lib/qml/MainWindow.qml",
@@ -90,13 +109,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mruby-zest/mruby-zest-build",
-                    "tag": "3.0.6-rc1",
-                    "commit": "934ccfd8f92d16dc83ee67a5349cc013c94e9c2b"
-                },
-                {
-                    "type":"file",
-                    "url":"http://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz",
-                    "sha256": "e83953782c916d7822ef0b94e8115ce5756fab5300cca173f0de5f5b0e0ae928"
+                    "tag": "3.0.6",
+                    "commit": "dd3d45ba333011f2359e86f9a758d9836e53fe5f"
                 },
                 {
                     "type": "patch",
@@ -121,7 +135,8 @@
             "cleanup": [
                 "/bin",
                 "/share/bash-completion",
-                "/share/doc"
+                "/share/doc",
+                "/share/applications"
             ],
             "post-install": [
                 "mv ${FLATPAK_DEST}/vst ${FLATPAK_DEST}/lxvst",
@@ -134,8 +149,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.sourceforge.net/sourceforge/zynaddsubfx/zynaddsubfx/3.0.5/zynaddsubfx-3.0.5.tar.bz2",
-                    "sha256": "7447322268114a1e0ac5f281ac37a09a78e761a7be61999caf79100049789f63"
+                    "url": "https://download.sourceforge.net/sourceforge/zynaddsubfx/zynaddsubfx/3.0.6/zynaddsubfx-3.0.6.tar.bz2",
+                    "sha256": "cbd160778f6cf147f9b0487719edc5197a1404f46d7c7bfd89e153f0d8ce71ae"
                 },
                 {
                     "type": "file",

--- a/org.freedesktop.LinuxAudio.Plugins.ZynFusion.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.ZynFusion.metainfo.xml
@@ -8,6 +8,7 @@
   <project_license>GPL-2.0+</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release date="2022-01-21" version="3.0.6" />
     <release date="2019-04-15" version="3.0.5" />
   </releases>
 </component>

--- a/zest_build-fixes.patch
+++ b/zest_build-fixes.patch
@@ -1,7 +1,9 @@
-diff --git a/Makefile b/Makefile
-index f3e3be2..c1d68d8 100644
---- a/Makefile
-+++ b/Makefile
-@@ -66 +66 @@ deps/$(UV_DIR):
--	cd deps              && wget -4 $(UV_URL) && tar xvf $(UV_FILE)
-+	cd deps              && tar xvf $(UV_FILE)
+--- zest/src/osc-bridge/Makefile-orig	2022-01-22 18:09:24.685969262 -0500
++++ zest/src/osc-bridge/Makefile	2022-01-22 18:09:37.196086093 -0500
+@@ -1,5 +1,5 @@
+ SRC = src/bridge.c src/cache.c src/parse-schema.c src/schema.c rtosc/rtosc.c
+-CFLAGS_ = -std=gnu99 -Wall -Wextra -I .
++CFLAGS_ = -std=gnu99 -Wall -Wextra -I . -I/app/extensions/Plugins/ZynFusion/include
+ 
+ all: mock-test remote-test lib
+ 


### PR DESCRIPTION
- libuv is now use from "system"
- some adjustement to include path for that
- fftw3f is now required too